### PR TITLE
Add kubernetes as a valid series

### DIFF
--- a/os.go
+++ b/os.go
@@ -16,6 +16,7 @@ const (
 	CentOS
 	GenericLinux
 	OpenSUSE
+	Kubernetes
 )
 
 func (t OSType) String() string {
@@ -32,6 +33,8 @@ func (t OSType) String() string {
 		return "GenericLinux"
 	case OpenSUSE:
 		return "OpenSUSE"
+	case Kubernetes:
+		return "Kubernetes"
 	}
 	return "Unknown"
 }

--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -101,6 +101,10 @@ var opensuseSeries = map[string]string{
 	"opensuseleap": "opensuse42",
 }
 
+var kubernetesSeries = map[string]string{
+	"kubernetes": "kubernetes",
+}
+
 var ubuntuSeries = map[string]string{
 	"precise": "12.04",
 	"quantal": "12.10",
@@ -232,6 +236,9 @@ func getOSFromSeries(series string) (os.OSType, error) {
 	}
 	if _, ok := opensuseSeries[series]; ok {
 		return os.OpenSUSE, nil
+	}
+	if _, ok := kubernetesSeries[series]; ok {
+		return os.Kubernetes, nil
 	}
 	if series == genericLinuxSeries {
 		return os.GenericLinux, nil

--- a/series/supportedseries_test.go
+++ b/series/supportedseries_test.go
@@ -47,6 +47,9 @@ var getOSFromSeriesTests = []struct {
 	series: "opensuseleap",
 	want:   os.OpenSUSE,
 }, {
+	series: "kubernetes",
+	want:   os.Kubernetes,
+}, {
 	series: "genericlinux",
 	want:   os.GenericLinux,
 }, {


### PR DESCRIPTION
We want GetOSFromSeries() to support "kubernetes" series.
We have agreed that "Kubernetes" should be the OS name.