### PR TITLE
 Supported juju series

### DIFF
--- a/series/export_linux_test.go
+++ b/series/export_linux_test.go
@@ -9,6 +9,9 @@ var (
 	OSReleaseFile = &osReleaseFile
 )
 
+// HideUbuntuSeries hides the global state of the ubuntu series for tests. The
+// function returns a closure, that puts the global state back once called.
+// This is not concurrent safe.
 func HideUbuntuSeries() func() {
 	origSeries := ubuntuSeries
 	ubuntuSeries = make(map[string]seriesVersion)

--- a/series/export_linux_test.go
+++ b/series/export_linux_test.go
@@ -9,9 +9,9 @@ var (
 	OSReleaseFile = &osReleaseFile
 )
 
-func SetUbuntuSeries(value map[string]string) func() {
+func HideUbuntuSeries() func() {
 	origSeries := ubuntuSeries
-	ubuntuSeries = value
+	ubuntuSeries = make(map[string]seriesVersion)
 	return func() {
 		ubuntuSeries = origSeries
 	}

--- a/series/series_linux.go
+++ b/series/series_linux.go
@@ -63,9 +63,9 @@ func getValue(from map[string]string, val string) (string, error) {
 }
 
 func getValueFromSeriesVersion(from map[string]seriesVersion, val string) (string, error) {
-	for serie, version := range from {
+	for s, version := range from {
 		if version.Version == val {
-			return serie, nil
+			return s, nil
 		}
 	}
 	return "unknown", errors.New("could not determine series")

--- a/series/series_linux.go
+++ b/series/series_linux.go
@@ -190,12 +190,12 @@ func updateDistroInfo() error {
 		// maintenance is supported from the following release cycle
 		// documentation https://www.ubuntu.com/about/release-cycle
 		var supported bool
-		if (ltsRelease || nonLTSSupported) && now.Before(eolDate) {
+		if (ltsRelease || nonLTSSupported) && now.After(releaseDate) && now.Before(eolDate) {
 			supported = true
 		}
 
 		var esmSupported bool
-		if ltsRelease && now.Before(eolESMDate) {
+		if ltsRelease && now.After(releaseDate) && now.Before(eolESMDate) {
 			esmSupported = true
 		}
 

--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -120,82 +120,69 @@ type seriesVersion struct {
 	LTS bool
 	// Supported defines if Juju classifies the series as officially supported.
 	Supported bool
+	// Extended security maintenance for customers, extends the supported bool
+	// for how Juju classifies the series.
+	ESMSupported bool
 }
 
 var ubuntuSeries = map[string]seriesVersion{
 	"precise": seriesVersion{
-		Version:   "12.04",
-		LTS:       true,
-		Supported: false,
+		Version: "12.04",
 	},
 	"quantal": seriesVersion{
-		Version:   "12.10",
-		LTS:       false,
-		Supported: false,
+		Version: "12.10",
 	},
 	"raring": seriesVersion{
-		Version:   "13.04",
-		LTS:       false,
-		Supported: false,
+		Version: "13.04",
 	},
 	"saucy": seriesVersion{
-		Version:   "13.10",
-		LTS:       false,
-		Supported: false,
+		Version: "13.10",
 	},
 	"trusty": seriesVersion{
-		Version:   "14.04",
-		LTS:       true,
-		Supported: true,
+		Version:      "14.04",
+		LTS:          true,
+		ESMSupported: true,
 	},
 	"utopic": seriesVersion{
-		Version:   "14.10",
-		LTS:       false,
-		Supported: true,
+		Version: "14.10",
 	},
 	"vivid": seriesVersion{
-		Version:   "15.04",
-		LTS:       false,
-		Supported: true,
+		Version: "15.04",
 	},
 	"wily": seriesVersion{
-		Version:   "15.10",
-		LTS:       false,
-		Supported: true,
+		Version: "15.10",
 	},
 	"xenial": seriesVersion{
-		Version:   "16.04",
-		LTS:       true,
-		Supported: true,
+		Version:      "16.04",
+		LTS:          true,
+		Supported:    true,
+		ESMSupported: true,
 	},
 	"yakkety": seriesVersion{
-		Version:   "16.10",
-		LTS:       false,
-		Supported: true,
+		Version: "16.10",
 	},
 	"zesty": seriesVersion{
-		Version:   "17.04",
-		LTS:       false,
-		Supported: true,
+		Version: "17.04",
 	},
 	"artful": seriesVersion{
-		Version:   "17.10",
-		LTS:       false,
-		Supported: true,
+		Version: "17.10",
 	},
 	"bionic": seriesVersion{
-		Version:   "18.04",
-		LTS:       true,
-		Supported: true,
+		Version:      "18.04",
+		LTS:          true,
+		Supported:    true,
+		ESMSupported: true,
 	},
 	"cosmic": seriesVersion{
 		Version:   "18.10",
-		LTS:       false,
 		Supported: true,
 	},
 	"disco": seriesVersion{
 		Version:   "19.04",
-		LTS:       false,
+		Supported: true,
+	},
+	"eoan": seriesVersion{
+		Version:   "19.10",
 		Supported: true,
 	},
 }
@@ -488,6 +475,22 @@ func SupportedJujuSeries() []string {
 	var series []string
 	for s, version := range ubuntuSeries {
 		if !version.Supported {
+			continue
+		}
+		series = append(series, s)
+	}
+	return series
+}
+
+// ESMSupportedJujuSeries returns a slice of just juju extended security
+// maintenance supported ubuntu series.
+func ESMSupportedJujuSeries() []string {
+	seriesVersionsMutex.Lock()
+	defer seriesVersionsMutex.Unlock()
+	updateSeriesVersionsOnce()
+	var series []string
+	for s, version := range ubuntuSeries {
+		if !version.ESMSupported {
 			continue
 		}
 		series = append(series, s)

--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -107,34 +107,96 @@ var kubernetesSeries = map[string]string{
 	"kubernetes": "kubernetes",
 }
 
-var ubuntuSeries = map[string]string{
-	"precise": "12.04",
-	"quantal": "12.10",
-	"raring":  "13.04",
-	"saucy":   "13.10",
-	"trusty":  "14.04",
-	"utopic":  "14.10",
-	"vivid":   "15.04",
-	"wily":    "15.10",
-	"xenial":  "16.04",
-	"yakkety": "16.10",
-	"zesty":   "17.04",
-	"artful":  "17.10",
-	"bionic":  "18.04",
-	"cosmic":  "18.10",
-	"disco":   "19.04",
+// seriesVersion represents a ubuntu series that includes the version, if the
+// series is an LTS and the supported defines if Juju supports the series
+// version.
+type seriesVersion struct {
+	Version string
+	// LTS provides a lookup for current LTS series.  Like seriesVersions,
+	// the values here are current at the time of writing. On Ubuntu systems this
+	// map is updated by updateDistroInfo, using data from
+	// /usr/share/distro-info/ubuntu.csv to ensure we have the latest values.  On
+	// non-Ubuntu systems, these values provide a nice fallback option.
+	LTS       bool
+	Supported bool
 }
 
-// ubuntuLTS provides a lookup for current LTS series.  Like seriesVersions,
-// the values here are current at the time of writing. On Ubuntu systems this
-// map is updated by updateDistroInfo, using data from
-// /usr/share/distro-info/ubuntu.csv to ensure we have the latest values.  On
-// non-Ubuntu systems, these values provide a nice fallback option.
-var ubuntuLTS = map[string]bool{
-	"precise": true,
-	"trusty":  true,
-	"xenial":  true,
-	"bionic":  true,
+var ubuntuSeries = map[string]seriesVersion{
+	"precise": seriesVersion{
+		Version:   "12.04",
+		LTS:       true,
+		Supported: false,
+	},
+	"quantal": seriesVersion{
+		Version:   "12.10",
+		LTS:       false,
+		Supported: false,
+	},
+	"raring": seriesVersion{
+		Version:   "13.04",
+		LTS:       false,
+		Supported: false,
+	},
+	"saucy": seriesVersion{
+		Version:   "13.10",
+		LTS:       false,
+		Supported: false,
+	},
+	"trusty": seriesVersion{
+		Version:   "14.04",
+		LTS:       true,
+		Supported: true,
+	},
+	"utopic": seriesVersion{
+		Version:   "14.10",
+		LTS:       false,
+		Supported: true,
+	},
+	"vivid": seriesVersion{
+		Version:   "15.04",
+		LTS:       false,
+		Supported: true,
+	},
+	"wily": seriesVersion{
+		Version:   "15.10",
+		LTS:       false,
+		Supported: true,
+	},
+	"xenial": seriesVersion{
+		Version:   "16.04",
+		LTS:       true,
+		Supported: true,
+	},
+	"yakkety": seriesVersion{
+		Version:   "16.10",
+		LTS:       false,
+		Supported: true,
+	},
+	"zesty": seriesVersion{
+		Version:   "17.04",
+		LTS:       false,
+		Supported: true,
+	},
+	"artful": seriesVersion{
+		Version:   "17.10",
+		LTS:       false,
+		Supported: true,
+	},
+	"bionic": seriesVersion{
+		Version:   "18.04",
+		LTS:       true,
+		Supported: true,
+	},
+	"cosmic": seriesVersion{
+		Version:   "18.10",
+		LTS:       false,
+		Supported: true,
+	},
+	"disco": seriesVersion{
+		Version:   "19.04",
+		LTS:       false,
+		Supported: true,
+	},
 }
 
 // Windows versions come in various flavors:
@@ -339,8 +401,11 @@ func SupportedLts() []string {
 	updateSeriesVersionsOnce()
 
 	versions := []string{}
-	for k := range ubuntuLTS {
-		versions = append(versions, ubuntuSeries[k])
+	for _, version := range ubuntuSeries {
+		if !version.LTS {
+			continue
+		}
+		versions = append(versions, version.Version)
 	}
 	sort.Strings(versions)
 	sorted := []string{}
@@ -365,8 +430,11 @@ func LatestLts() string {
 	updateSeriesVersionsOnce()
 
 	var latest string
-	for k := range ubuntuLTS {
-		if ubuntuSeries[k] > ubuntuSeries[latest] {
+	for k, version := range ubuntuSeries {
+		if !version.LTS {
+			continue
+		}
+		if version.Version > ubuntuSeries[latest].Version {
 			latest = k
 		}
 	}

--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -115,9 +115,10 @@ type seriesVersion struct {
 	// LTS provides a lookup for current LTS series.  Like seriesVersions,
 	// the values here are current at the time of writing. On Ubuntu systems this
 	// map is updated by updateDistroInfo, using data from
-	// /usr/share/distro-info/ubuntu.csv to ensure we have the latest values.  On
+	// /usr/share/distro-info/ubuntu.csv to ensure we have the latest values. On
 	// non-Ubuntu systems, these values provide a nice fallback option.
-	LTS       bool
+	LTS bool
+	// Supported defines if Juju classifies the series as officially supported.
 	Supported bool
 }
 
@@ -474,6 +475,21 @@ func SupportedSeries() []string {
 	updateSeriesVersionsOnce()
 	var series []string
 	for s := range seriesVersions {
+		series = append(series, s)
+	}
+	return series
+}
+
+// SupportedJujuSeries returns a slice of just juju supported ubuntu series.
+func SupportedJujuSeries() []string {
+	seriesVersionsMutex.Lock()
+	defer seriesVersionsMutex.Unlock()
+	updateSeriesVersionsOnce()
+	var series []string
+	for s, version := range ubuntuSeries {
+		if !version.Supported {
+			continue
+		}
 		series = append(series, s)
 	}
 	return series

--- a/series/supportedseries_linux_test.go
+++ b/series/supportedseries_linux_test.go
@@ -77,7 +77,7 @@ func (s *supportedSeriesSuite) TestSupportedJujuSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(series.DistroInfo, filename)
 
-	expectedSeries := []string{"bionic", "cosmic", "disco", "eoan", "xenial"}
+	expectedSeries := []string{"bionic", "cosmic", "disco", "xenial"}
 	series := series.SupportedJujuSeries()
 	sort.Strings(series)
 	c.Assert(series, gc.DeepEquals, expectedSeries)

--- a/series/supportedseries_linux_test.go
+++ b/series/supportedseries_linux_test.go
@@ -77,8 +77,21 @@ func (s *supportedSeriesSuite) TestSupportedJujuSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(series.DistroInfo, filename)
 
-	expectedSeries := []string{"artful", "bionic", "cosmic", "disco", "eoan", "trusty", "utopic", "vivid", "wily", "xenial", "yakkety", "zesty"}
+	expectedSeries := []string{"bionic", "cosmic", "disco", "eoan", "xenial"}
 	series := series.SupportedJujuSeries()
+	sort.Strings(series)
+	c.Assert(series, gc.DeepEquals, expectedSeries)
+}
+
+func (s *supportedSeriesSuite) TestESMSupportedJujuSeries(c *gc.C) {
+	d := c.MkDir()
+	filename := filepath.Join(d, "ubuntu.csv")
+	err := ioutil.WriteFile(filename, []byte(distInfoData), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	s.PatchValue(series.DistroInfo, filename)
+
+	expectedSeries := []string{"bionic", "trusty", "xenial"}
+	series := series.ESMSupportedJujuSeries()
 	sort.Strings(series)
 	c.Assert(series, gc.DeepEquals, expectedSeries)
 }

--- a/series/supportedseries_linux_test.go
+++ b/series/supportedseries_linux_test.go
@@ -35,7 +35,7 @@ func (s *supportedSeriesSuite) TestSupportedSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(series.DistroInfo, filename)
 
-	expectedSeries := []string{"precise", "quantal", "raring", "saucy"}
+	expectedSeries := []string{"artful", "bionic", "cosmic", "disco", "eoan", "precise", "quantal", "raring", "saucy", "trusty", "utopic", "vivid", "wily", "xenial", "yakkety", "zesty"}
 	series := series.SupportedSeries()
 	sort.Strings(series)
 	c.Assert(series, gc.DeepEquals, expectedSeries)
@@ -48,7 +48,7 @@ func (s *supportedSeriesSuite) TestUpdateSeriesVersions(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(series.DistroInfo, filename)
 
-	expectedSeries := []string{"precise", "quantal", "raring", "saucy"}
+	expectedSeries := []string{"artful", "bionic", "cosmic", "disco", "eoan", "precise", "quantal", "raring", "saucy", "trusty", "utopic", "vivid", "wily", "xenial", "yakkety", "zesty"}
 	checkSeries := func() {
 		series := series.SupportedSeries()
 		sort.Strings(series)
@@ -64,14 +64,16 @@ func (s *supportedSeriesSuite) TestUpdateSeriesVersions(c *gc.C) {
 	checkSeries()
 
 	expectedSeries = append([]string{"ornery"}, expectedSeries...)
-	expectedSeries = append(expectedSeries, "trusty")
+	expectedSeries = append(expectedSeries, "firewolf")
+	sort.Strings(expectedSeries)
 	series.UpdateSeriesVersions()
 	checkSeries()
 }
 
 func (s *supportedSeriesSuite) TestOSSeries(c *gc.C) {
-	cleanup := series.SetUbuntuSeries(make(map[string]string))
-	defer cleanup()
+	restore := series.HideUbuntuSeries()
+	defer restore()
+
 	d := c.MkDir()
 	filename := filepath.Join(d, "ubuntu.csv")
 	err := ioutil.WriteFile(filename, []byte(distInfoData), 0644)
@@ -83,7 +85,7 @@ func (s *supportedSeriesSuite) TestOSSeries(c *gc.C) {
 	c.Assert(osType, gc.Equals, os.Ubuntu)
 }
 
-const distInfoData = `version,codename,series,created,release,eol,eol-server
+const distInfoData = `version,codename,series,created,release,eol,eol-server,eol-esm
 4.10,Warty Warthog,warty,2004-03-05,2004-10-20,2006-04-30
 5.04,Hoary Hedgehog,hoary,2004-10-20,2005-04-08,2006-10-31
 5.10,Breezy Badger,breezy,2005-04-08,2005-10-12,2007-04-13
@@ -99,13 +101,25 @@ const distInfoData = `version,codename,series,created,release,eol,eol-server
 10.10,Maverick Meerkat,maverick,2010-04-29,2010-10-10,2012-04-10
 11.04,Natty Narwhal,natty,2010-10-10,2011-04-28,2012-10-28
 11.10,Oneiric Ocelot,oneiric,2011-04-28,2011-10-13,2013-05-09
-12.04 LTS,Precise Pangolin,precise,2011-10-13,2012-04-26,2017-04-26
-12.10,Quantal Quetzal,quantal,2012-04-26,2012-10-18,2014-04-18
+12.04 LTS,Precise Pangolin,precise,2011-10-13,2012-04-26,2017-04-26,2017-04-26,2019-04-26
+12.10,Quantal Quetzal,quantal,2012-04-26,2012-10-18,2014-05-16
 13.04,Raring Ringtail,raring,2012-10-18,2013-04-25,2014-01-27
 13.10,Saucy Salamander,saucy,2013-04-25,2013-10-17,2014-07-17
+14.04 LTS,Trusty Tahr,trusty,2013-10-17,2014-04-17,2019-04-17,2019-04-17,2022-04-17
+14.10,Utopic Unicorn,utopic,2014-04-17,2014-10-23,2015-07-23
+15.04,Vivid Vervet,vivid,2014-10-23,2015-04-23,2016-01-23
+15.10,Wily Werewolf,wily,2015-04-23,2015-10-22,2016-07-22
+16.04 LTS,Xenial Xerus,xenial,2015-10-22,2016-04-21,2021-04-21,2021-04-21,2024-04-21
+16.10,Yakkety Yak,yakkety,2016-04-21,2016-10-13,2017-07-20
+17.04,Zesty Zapus,zesty,2016-10-13,2017-04-13,2018-01-13
+17.10,Artful Aardvark,artful,2017-04-13,2017-10-19,2018-07-19
+18.04 LTS,Bionic Beaver,bionic,2017-10-19,2018-04-26,2023-04-26,2023-04-26,2028-04-26
+18.10,Cosmic Cuttlefish,cosmic,2018-04-26,2018-10-18,2019-07-18
+19.04,Disco Dingo,disco,2018-10-18,2019-04-18,2020-01-18
+19.10,Eoan EANIMAL,eoan,2019-04-18,2019-10-17,2020-07-17
 `
 
 const distInfoData2 = distInfoData + `
-14.04 LTS,Trusty Tahr,trusty,2013-10-17,2014-04-17,2019-04-17
+14.04 LTS,Firewolf,firewolf,2013-10-17,2014-04-17,2019-04-17
 94.04 LTS,Ornery Omega,ornery,2094-10-17,2094-04-17,2099-04-17
 `

--- a/series/supportedseries_linux_test.go
+++ b/series/supportedseries_linux_test.go
@@ -70,6 +70,19 @@ func (s *supportedSeriesSuite) TestUpdateSeriesVersions(c *gc.C) {
 	checkSeries()
 }
 
+func (s *supportedSeriesSuite) TestSupportedJujuSeries(c *gc.C) {
+	d := c.MkDir()
+	filename := filepath.Join(d, "ubuntu.csv")
+	err := ioutil.WriteFile(filename, []byte(distInfoData), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	s.PatchValue(series.DistroInfo, filename)
+
+	expectedSeries := []string{"artful", "bionic", "cosmic", "disco", "eoan", "trusty", "utopic", "vivid", "wily", "xenial", "yakkety", "zesty"}
+	series := series.SupportedJujuSeries()
+	sort.Strings(series)
+	c.Assert(series, gc.DeepEquals, expectedSeries)
+}
+
 func (s *supportedSeriesSuite) TestOSSeries(c *gc.C) {
 	restore := series.HideUbuntuSeries()
 	defer restore()


### PR DESCRIPTION
The following exposes the ability to see what version of ubuntu
release is supported from a juju perspective.

Unfortunately we have to state which version we do support, trusty
LTS and greater, but this is manual and probably not precise.

Additionally the code unifies all the ubuntu maps, so it's easier to 
grok and maintain. The supported bool on the seriesVersion defines 
if juju also supports the ubuntu release or not.