### PR TITLE
Add non Ubuntu series to SupportedJujuSeries() 

### DIFF
--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -75,6 +75,7 @@ var seriesVersions = map[string]string{
 	"bionic":           "18.04",
 	"cosmic":           "18.10",
 	"disco":            "19.04",
+	"eoan":             "19.10",
 	"win2008r2":        "win2008r2",
 	"win2012hvr2":      "win2012hvr2",
 	"win2012hv":        "win2012hv",
@@ -183,6 +184,73 @@ var ubuntuSeries = map[string]seriesVersion{
 	},
 	"eoan": seriesVersion{
 		Version:   "19.10",
+		Supported: true,
+	},
+}
+
+var nonUbuntuSeries = map[string]seriesVersion{
+	"win2008r2":        {
+		Version:"win2008r2",
+		Supported: true,
+	},
+	"win2012hvr2":      {
+		Version: "win2012hvr2",
+		Supported: true,
+	},
+	"win2012hv":        {
+		Version: "win2012hv",
+		Supported: true,
+	},
+	"win2012r2":        {
+		Version: "win2012r2",
+		Supported: true,
+	},
+	"win2012":          {
+		Version: "win2012",
+		Supported: true,
+	},
+	"win2016":         {
+		Version:  "win2016",
+		Supported: true,
+	},
+	"win2016hv":       {
+		Version:  "win2016hv",
+		Supported: true,
+	},
+	"win2016nano":      {
+		Version: "win2016nano",
+		Supported: true,
+	},
+	"win7":           {
+		Version:   "win7",
+		Supported: true,
+	},
+	"win8":          {
+		Version:    "win8",
+		Supported: true,
+	},
+	"win81":           {
+		Version:  "win81",
+		Supported: true,
+	},
+	"win10":         {
+		Version:    "win10",
+		Supported: true,
+	},
+	"centos7":        {
+		Version:   "centos7",
+		Supported: true,
+	},
+	"opensuseleap":    {
+		Version:  "opensuse42",
+		Supported: true,
+	},
+	genericLinuxSeries: {
+		Version: genericLinuxVersion,
+		Supported: true,
+	},
+	"kubernetes":  {
+		Version:"kubernetes",
 		Supported: true,
 	},
 }
@@ -467,13 +535,24 @@ func SupportedSeries() []string {
 	return series
 }
 
-// SupportedJujuSeries returns a slice of just juju supported ubuntu series.
+func allSeriesVersions() map[string]seriesVersion{
+	all := map[string]seriesVersion{}
+	for k, v := range ubuntuSeries{
+		all[k] = v
+	}
+	for k, v := range nonUbuntuSeries{
+		all[k] = v
+	}
+	return all
+}
+
+// SupportedJujuSeries returns a slice of juju supported series.
 func SupportedJujuSeries() []string {
 	seriesVersionsMutex.Lock()
 	defer seriesVersionsMutex.Unlock()
 	updateSeriesVersionsOnce()
 	var series []string
-	for s, version := range ubuntuSeries {
+	for s, version := range allSeriesVersions() {
 		if !version.Supported {
 			continue
 		}

--- a/series/supportedseries_linux_test.go
+++ b/series/supportedseries_linux_test.go
@@ -70,19 +70,6 @@ func (s *supportedSeriesSuite) TestUpdateSeriesVersions(c *gc.C) {
 	checkSeries()
 }
 
-func (s *supportedSeriesSuite) TestSupportedJujuSeries(c *gc.C) {
-	d := c.MkDir()
-	filename := filepath.Join(d, "ubuntu.csv")
-	err := ioutil.WriteFile(filename, []byte(distInfoData), 0644)
-	c.Assert(err, jc.ErrorIsNil)
-	s.PatchValue(series.DistroInfo, filename)
-
-	expectedSeries := []string{"bionic", "cosmic", "disco", "xenial"}
-	series := series.SupportedJujuSeries()
-	sort.Strings(series)
-	c.Assert(series, gc.DeepEquals, expectedSeries)
-}
-
 func (s *supportedSeriesSuite) TestESMSupportedJujuSeries(c *gc.C) {
 	d := c.MkDir()
 	filename := filepath.Join(d, "ubuntu.csv")
@@ -93,7 +80,7 @@ func (s *supportedSeriesSuite) TestESMSupportedJujuSeries(c *gc.C) {
 	expectedSeries := []string{"bionic", "trusty", "xenial"}
 	series := series.ESMSupportedJujuSeries()
 	sort.Strings(series)
-	c.Assert(series, gc.DeepEquals, expectedSeries)
+	c.Assert(series, jc.SameContents, expectedSeries)
 }
 
 func (s *supportedSeriesSuite) TestOSSeries(c *gc.C) {

--- a/series/supportedseries_test.go
+++ b/series/supportedseries_test.go
@@ -4,6 +4,10 @@
 package series_test
 
 import (
+	"io/ioutil"
+	"sort"
+	"path/filepath"
+
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -175,3 +179,17 @@ func (s *supportedSeriesSuite) TestSupportedLts(c *gc.C) {
 	want := []string{"precise", "trusty", "xenial", "bionic"}
 	c.Assert(got, gc.DeepEquals, want)
 }
+
+func (s *supportedSeriesSuite) TestSupportedJujuSeries(c *gc.C) {
+	d := c.MkDir()
+	filename := filepath.Join(d, "ubuntu.csv")
+	err := ioutil.WriteFile(filename, []byte(distInfoData), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	s.PatchValue(series.DistroInfo, filename)
+
+	expectedSeries := []string{"bionic", "centos7", "cosmic", "disco", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win7", "win8", "win81", "xenial"}
+	series := series.SupportedJujuSeries()
+	sort.Strings(series)
+	c.Assert(series, jc.SameContents, expectedSeries)
+}
+


### PR DESCRIPTION
Add non Ubuntu series to SupportedJujuSeries().  For now, all non Ubuntu series are supported until a retirement plan is defined and implemented.