### PR TITLE
Warning info whilst parsing

### DIFF
--- a/series/series_linux.go
+++ b/series/series_linux.go
@@ -84,8 +84,9 @@ func ReleaseVersion() string {
 
 var distroInfo = "/usr/share/distro-info/ubuntu.csv"
 
-// updateDistroInfo updates seriesVersions from /usr/share/distro-info/ubuntu.csv if possible..
-func updateDistroInfo() error {
+// updateLocalSeriesVersions updates seriesVersions from
+// /usr/share/distro-info/ubuntu.csv if possible..
+func updateLocalSeriesVersions() error {
 	// We need to find the series version eg 12.04 from the series eg precise. Use the information found in
 	// /usr/share/distro-info/ubuntu.csv provided by distro-info-data package.
 	f, err := os.Open(distroInfo)
@@ -156,14 +157,14 @@ func updateDistroInfo() error {
 			// we should add 5 years to the release date in case of an error
 			// parsing the eol date.
 			eolDate = releaseDate.Add(5 * year)
-			warnings = append(warnings, "EOL date not found so falling back to release date, plus 5 years")
+			warnings = append(warnings, "EOL date not found, falling back to release date, plus 5 years")
 		}
 
 		eolESMDate, err := time.Parse("2006-01-02", eolESM)
 		if err != nil {
 			// fall back to the eolDate if none is provided in the csv.
 			eolESMDate = eolDate
-			warnings = append(warnings, "EOL ESM date not found so falling back to EOL date")
+			warnings = append(warnings, "EOL ESM date not found, falling back to EOL date")
 		}
 
 		// The numeric version may contain a LTS moniker so strip that out.

--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -124,6 +124,8 @@ type seriesVersion struct {
 	// Extended security maintenance for customers, extends the supported bool
 	// for how Juju classifies the series.
 	ESMSupported bool
+	// WarningInfo used for when parsing the CSV about local distro information
+	WarningInfo []string
 }
 
 var ubuntuSeries = map[string]seriesVersion{
@@ -189,68 +191,68 @@ var ubuntuSeries = map[string]seriesVersion{
 }
 
 var nonUbuntuSeries = map[string]seriesVersion{
-	"win2008r2":        {
-		Version:"win2008r2",
+	"win2008r2": {
+		Version:   "win2008r2",
 		Supported: true,
 	},
-	"win2012hvr2":      {
-		Version: "win2012hvr2",
+	"win2012hvr2": {
+		Version:   "win2012hvr2",
 		Supported: true,
 	},
-	"win2012hv":        {
-		Version: "win2012hv",
+	"win2012hv": {
+		Version:   "win2012hv",
 		Supported: true,
 	},
-	"win2012r2":        {
-		Version: "win2012r2",
+	"win2012r2": {
+		Version:   "win2012r2",
 		Supported: true,
 	},
-	"win2012":          {
-		Version: "win2012",
+	"win2012": {
+		Version:   "win2012",
 		Supported: true,
 	},
-	"win2016":         {
-		Version:  "win2016",
+	"win2016": {
+		Version:   "win2016",
 		Supported: true,
 	},
-	"win2016hv":       {
-		Version:  "win2016hv",
+	"win2016hv": {
+		Version:   "win2016hv",
 		Supported: true,
 	},
-	"win2016nano":      {
-		Version: "win2016nano",
+	"win2016nano": {
+		Version:   "win2016nano",
 		Supported: true,
 	},
-	"win7":           {
+	"win7": {
 		Version:   "win7",
 		Supported: true,
 	},
-	"win8":          {
-		Version:    "win8",
+	"win8": {
+		Version:   "win8",
 		Supported: true,
 	},
-	"win81":           {
-		Version:  "win81",
+	"win81": {
+		Version:   "win81",
 		Supported: true,
 	},
-	"win10":         {
-		Version:    "win10",
+	"win10": {
+		Version:   "win10",
 		Supported: true,
 	},
-	"centos7":        {
+	"centos7": {
 		Version:   "centos7",
 		Supported: true,
 	},
-	"opensuseleap":    {
-		Version:  "opensuse42",
+	"opensuseleap": {
+		Version:   "opensuse42",
 		Supported: true,
 	},
 	genericLinuxSeries: {
-		Version: genericLinuxVersion,
+		Version:   genericLinuxVersion,
 		Supported: true,
 	},
-	"kubernetes":  {
-		Version:"kubernetes",
+	"kubernetes": {
+		Version:   "kubernetes",
 		Supported: true,
 	},
 }
@@ -535,12 +537,12 @@ func SupportedSeries() []string {
 	return series
 }
 
-func allSeriesVersions() map[string]seriesVersion{
+func allSeriesVersions() map[string]seriesVersion {
 	all := map[string]seriesVersion{}
-	for k, v := range ubuntuSeries{
+	for k, v := range ubuntuSeries {
 		all[k] = v
 	}
-	for k, v := range nonUbuntuSeries{
+	for k, v := range nonUbuntuSeries {
 		all[k] = v
 	}
 	return all
@@ -577,6 +579,19 @@ func ESMSupportedJujuSeries() []string {
 	return series
 }
 
+// SeriesWarningInfo returns any potential warnings about a particular series
+// when parsing data from the system.
+func SeriesWarningInfo(version string) []string {
+	seriesVersionsMutex.Lock()
+	defer seriesVersionsMutex.Unlock()
+	updateSeriesVersionsOnce()
+
+	if s, ok := ubuntuSeries[version]; ok {
+		return s.WarningInfo
+	}
+	return nil
+}
+
 // OSSupportedSeries returns the series of the specified OS on which we
 // can run Juju workloads.
 func OSSupportedSeries(os os.OSType) []string {
@@ -596,7 +611,7 @@ func OSSupportedSeries(os os.OSType) []string {
 func UpdateSeriesVersions() error {
 	seriesVersionsMutex.Lock()
 	defer seriesVersionsMutex.Unlock()
-	err := updateLocalSeriesVersions()
+	err := updateDistroInfo()
 	if err != nil {
 		return err
 	}
@@ -609,7 +624,7 @@ var updatedseriesVersions bool
 
 func updateSeriesVersionsOnce() {
 	if !updatedseriesVersions {
-		if err := updateLocalSeriesVersions(); err != nil {
+		if err := updateDistroInfo(); err != nil {
 			logger.Warningf("failed to update distro info: %v", err)
 		}
 		updateVersionSeries()

--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -124,7 +124,8 @@ type seriesVersion struct {
 	// Extended security maintenance for customers, extends the supported bool
 	// for how Juju classifies the series.
 	ESMSupported bool
-	// WarningInfo used for when parsing the CSV about local distro information
+	// WarningInfo shows any potential issues when parsing the series version
+	// information.
 	WarningInfo []string
 }
 
@@ -611,7 +612,7 @@ func OSSupportedSeries(os os.OSType) []string {
 func UpdateSeriesVersions() error {
 	seriesVersionsMutex.Lock()
 	defer seriesVersionsMutex.Unlock()
-	err := updateDistroInfo()
+	err := updateLocalSeriesVersions()
 	if err != nil {
 		return err
 	}
@@ -624,7 +625,7 @@ var updatedseriesVersions bool
 
 func updateSeriesVersionsOnce() {
 	if !updatedseriesVersions {
-		if err := updateDistroInfo(); err != nil {
+		if err := updateLocalSeriesVersions(); err != nil {
 			logger.Warningf("failed to update distro info: %v", err)
 		}
 		updateVersionSeries()

--- a/series/supportedseries_linux_test.go
+++ b/series/supportedseries_linux_test.go
@@ -92,8 +92,8 @@ func (s *supportedSeriesSuite) TestWarningInfoForInvalidParsing(c *gc.C) {
 
 	info := series.SeriesWarningInfo("firewolf")
 	c.Assert(info, jc.SameContents, []string{
-		"EOL date not found so falling back to release date, plus 5 years",
-		"EOL ESM date not found so falling back to EOL date",
+		"EOL date not found, falling back to release date, plus 5 years",
+		"EOL ESM date not found, falling back to EOL date",
 	})
 }
 

--- a/series/supportedseries_linux_test.go
+++ b/series/supportedseries_linux_test.go
@@ -83,6 +83,20 @@ func (s *supportedSeriesSuite) TestESMSupportedJujuSeries(c *gc.C) {
 	c.Assert(series, jc.SameContents, expectedSeries)
 }
 
+func (s *supportedSeriesSuite) TestWarningInfoForInvalidParsing(c *gc.C) {
+	d := c.MkDir()
+	filename := filepath.Join(d, "ubuntu.csv")
+	err := ioutil.WriteFile(filename, []byte(distInfoData2), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	s.PatchValue(series.DistroInfo, filename)
+
+	info := series.SeriesWarningInfo("firewolf")
+	c.Assert(info, jc.SameContents, []string{
+		"EOL date not found so falling back to release date, plus 5 years",
+		"EOL ESM date not found so falling back to EOL date",
+	})
+}
+
 func (s *supportedSeriesSuite) TestOSSeries(c *gc.C) {
 	restore := series.HideUbuntuSeries()
 	defer restore()
@@ -133,6 +147,6 @@ const distInfoData = `version,codename,series,created,release,eol,eol-server,eol
 `
 
 const distInfoData2 = distInfoData + `
-14.04 LTS,Firewolf,firewolf,2013-10-17,2014-04-17,2019-04-17
+14.04 LTS,Firewolf,firewolf,2013-10-17,2014-04-17
 94.04 LTS,Ornery Omega,ornery,2094-10-17,2094-04-17,2099-04-17
 `

--- a/series/supportedseries_test.go
+++ b/series/supportedseries_test.go
@@ -5,8 +5,8 @@ package series_test
 
 import (
 	"io/ioutil"
-	"sort"
 	"path/filepath"
+	"sort"
 
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -192,4 +192,3 @@ func (s *supportedSeriesSuite) TestSupportedJujuSeries(c *gc.C) {
 	sort.Strings(series)
 	c.Assert(series, jc.SameContents, expectedSeries)
 }
-


### PR DESCRIPTION
Add additional warning information to the series linux, so when
we're attempting to parse the supported series we can get that
information at a later date.