### PR TITLE
Remove the enter window

### DIFF
--- a/series/series_linux.go
+++ b/series/series_linux.go
@@ -185,8 +185,8 @@ func updateLocalSeriesVersions() error {
 		ubuntuSeries[series] = seriesVersion{
 			Version:      trimmedVersion,
 			LTS:          ltsRelease,
-			Supported:    now.After(releaseDate) && now.Before(eolDate),
-			ESMSupported: ltsRelease && now.After(releaseDate) && now.Before(eolESMDate),
+			Supported:    now.Before(eolDate),
+			ESMSupported: ltsRelease && now.Before(eolESMDate),
 			WarningInfo:  warnings,
 		}
 	}

--- a/series/supportedseries_test.go
+++ b/series/supportedseries_test.go
@@ -187,8 +187,9 @@ func (s *supportedSeriesSuite) TestSupportedJujuSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(series.DistroInfo, filename)
 
-	expectedSeries := []string{"bionic", "centos7", "cosmic", "disco", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win7", "win8", "win81", "xenial"}
+	expectedSeries := []string{"bionic", "centos7", "disco", "eoan", "genericlinux", "kubernetes", "opensuseleap", "spock", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win7", "win8", "win81", "xenial"}
 	series := series.SupportedJujuSeries()
 	sort.Strings(series)
+	sort.Strings(expectedSeries)
 	c.Assert(series, jc.SameContents, expectedSeries)
 }


### PR DESCRIPTION
Instead of having an entry window, we should just check if the exit
window (before date) is ended. That way we can test new releases
easily without having to jump through hoops with the force flag.

Ensure that tests pass.