### PR TITLE
Remove supported updates from distro info

### DIFF
--- a/series/export_test.go
+++ b/series/export_test.go
@@ -21,3 +21,8 @@ func SetSeriesVersions(value map[string]string) func() {
 		updatedseriesVersions = origUpdated
 	}
 }
+
+// UbuntuSupportedSeries exports the ubuntuSeries for testing.
+func UbuntuSupportedSeries() map[string]seriesVersion {
+	return ubuntuSeries
+}

--- a/series/series_linux_test.go
+++ b/series/series_linux_test.go
@@ -59,6 +59,28 @@ func (s *linuxVersionSuite) TestOSVersion(c *gc.C) {
 	version, err := series.ReadSeries()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(version, gc.Equals, "spock")
+
+	// Ensure that we identify that the poly-filled os releases from distro-info
+	// don't change supported values.
+	series := series.UbuntuSupportedSeries()
+
+	// Precise isn't poly-filled and isn't supported.
+	precise, ok := series["precise"]
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(precise.CreatedByLocalDistroInfo, jc.IsFalse)
+	c.Assert(precise.Supported, jc.IsFalse)
+
+	// Bionic isn't poly-filled and is supported.
+	bionic, ok := series["bionic"]
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(bionic.CreatedByLocalDistroInfo, jc.IsFalse)
+	c.Assert(bionic.Supported, jc.IsTrue)
+
+	// Spock is poly-filled and isn't supported.
+	spock, ok := series["spock"]
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(spock.CreatedByLocalDistroInfo, jc.IsTrue)
+	c.Assert(spock.Supported, jc.IsFalse)
 }
 
 func (s *linuxVersionSuite) TestUseFastLXC(c *gc.C) {

--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -114,10 +114,7 @@ var kubernetesSeries = map[string]string{
 type seriesVersion struct {
 	Version string
 	// LTS provides a lookup for current LTS series.  Like seriesVersions,
-	// the values here are current at the time of writing. On Ubuntu systems this
-	// map is updated by updateDistroInfo, using data from
-	// /usr/share/distro-info/ubuntu.csv to ensure we have the latest values. On
-	// non-Ubuntu systems, these values provide a nice fallback option.
+	// the values here are current at the time of writing.
 	LTS bool
 	// Supported defines if Juju classifies the series as officially supported.
 	Supported bool
@@ -127,6 +124,10 @@ type seriesVersion struct {
 	// WarningInfo shows any potential issues when parsing the series version
 	// information.
 	WarningInfo []string
+	// CreatedByLocalDistroInfo indecates that the series version was created
+	// by the local distro-info information on the system.
+	// This is useful to understand why a version appears yet is not supported.
+	CreatedByLocalDistroInfo bool
 }
 
 var ubuntuSeries = map[string]seriesVersion{
@@ -578,19 +579,6 @@ func ESMSupportedJujuSeries() []string {
 		series = append(series, s)
 	}
 	return series
-}
-
-// SeriesWarningInfo returns any potential warnings about a particular series
-// when parsing data from the system.
-func SeriesWarningInfo(version string) []string {
-	seriesVersionsMutex.Lock()
-	defer seriesVersionsMutex.Unlock()
-	updateSeriesVersionsOnce()
-
-	if s, ok := ubuntuSeries[version]; ok {
-		return s.WarningInfo
-	}
-	return nil
 }
 
 // OSSupportedSeries returns the series of the specified OS on which we

--- a/series/supportedseries_linux_test.go
+++ b/series/supportedseries_linux_test.go
@@ -83,20 +83,6 @@ func (s *supportedSeriesSuite) TestESMSupportedJujuSeries(c *gc.C) {
 	c.Assert(series, jc.SameContents, expectedSeries)
 }
 
-func (s *supportedSeriesSuite) TestWarningInfoForInvalidParsing(c *gc.C) {
-	d := c.MkDir()
-	filename := filepath.Join(d, "ubuntu.csv")
-	err := ioutil.WriteFile(filename, []byte(distInfoData2), 0644)
-	c.Assert(err, jc.ErrorIsNil)
-	s.PatchValue(series.DistroInfo, filename)
-
-	info := series.SeriesWarningInfo("firewolf")
-	c.Assert(info, jc.SameContents, []string{
-		"EOL date not found, falling back to release date, plus 5 years",
-		"EOL ESM date not found, falling back to EOL date",
-	})
-}
-
 func (s *supportedSeriesSuite) TestOSSeries(c *gc.C) {
 	restore := series.HideUbuntuSeries()
 	defer restore()

--- a/series/supportedseries_test.go
+++ b/series/supportedseries_test.go
@@ -176,7 +176,7 @@ func (s *supportedSeriesSuite) TestSetLatestLtsForTesting(c *gc.C) {
 
 func (s *supportedSeriesSuite) TestSupportedLts(c *gc.C) {
 	got := series.SupportedLts()
-	want := []string{"precise", "trusty", "xenial", "bionic"}
+	want := []string{"trusty", "xenial", "bionic"}
 	c.Assert(got, gc.DeepEquals, want)
 }
 
@@ -187,7 +187,7 @@ func (s *supportedSeriesSuite) TestSupportedJujuSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(series.DistroInfo, filename)
 
-	expectedSeries := []string{"bionic", "centos7", "disco", "eoan", "genericlinux", "kubernetes", "opensuseleap", "spock", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win7", "win8", "win81", "xenial"}
+	expectedSeries := []string{"bionic", "centos7", "cosmic", "disco", "eoan", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win7", "win8", "win81", "xenial"}
 	series := series.SupportedJujuSeries()
 	sort.Strings(series)
 	sort.Strings(expectedSeries)


### PR DESCRIPTION
The following commit removes the poly-fill from the distro info
csv file, when updating the Juju supported series. The basic idea
here is that Juju as a project needs to know what series it supports
and works with. New releases of ubuntu can throw up some new changes
that we might not of anticipated (netplan, systemd). So Juju will
need to have a better understanding and consideration around how
the Juju code works against new releases before allowing things to
be bootstrapped or deployed.

New series are still added to the supported series list for a couple
of reasons:
 1. We can use the series name for validation when deploying and
    bootstrapping
 2. We can identify those new os releases as we've added a new bool
    to highlight those if required.

It should be noted that all of this isn't relevant when the use of
`--force` is used in those scenarios. At that point the onus is on
the operator as they're bypassing the recommendations.