### PR TITLE
Adding ubuntu series

### DIFF
--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -415,6 +415,24 @@ func SeriesVersion(series string) (string, error) {
 	return "", errors.Trace(unknownSeriesVersionError(series))
 }
 
+// UbuntuSeriesVersion returns the ubuntu version for the specified series.
+func UbuntuSeriesVersion(series string) (string, error) {
+	if series == "" {
+		return "", errors.Trace(unknownSeriesVersionError(""))
+	}
+	seriesVersionsMutex.Lock()
+	defer seriesVersionsMutex.Unlock()
+	if vers, ok := ubuntuSeries[series]; ok {
+		return vers.Version, nil
+	}
+	updateSeriesVersionsOnce()
+	if vers, ok := ubuntuSeries[series]; ok {
+		return vers.Version, nil
+	}
+
+	return "", errors.Trace(unknownSeriesVersionError(series))
+}
+
 // VersionSeries returns the series (e.g.trusty) for the specified version (e.g. 14.04).
 func VersionSeries(version string) (string, error) {
 	if version == "" {

--- a/series/supportedseries_test.go
+++ b/series/supportedseries_test.go
@@ -137,6 +137,33 @@ func (s *supportedSeriesSuite) TestSeriesVersionEmpty(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `.*unknown version for series: "".*`)
 }
 
+func (s *supportedSeriesSuite) TestUbuntuSeriesVersionEmpty(c *gc.C) {
+	_, err := series.UbuntuSeriesVersion("")
+	c.Assert(err, gc.ErrorMatches, `.*unknown version for series: "".*`)
+}
+
+func (s *supportedSeriesSuite) TestUbuntuSeriesVersion(c *gc.C) {
+	isUbuntuTests := []struct {
+		series   string
+		expected string
+	}{
+		{"precise", "12.04"},
+		{"raring", "13.04"},
+		{"bionic", "18.04"},
+		{"eoan", "19.10"},
+	}
+	for _, v := range isUbuntuTests {
+		ver, err := series.UbuntuSeriesVersion(v.series)
+		c.Assert(err, gc.IsNil)
+		c.Assert(ver, gc.Equals, v.expected)
+	}
+}
+
+func (s *supportedSeriesSuite) TestUbuntuInvalidSeriesVersion(c *gc.C) {
+	_, err := series.UbuntuSeriesVersion("firewolf")
+	c.Assert(err, gc.ErrorMatches, `.*unknown version for series: "firewolf".*`)
+}
+
 func (s *supportedSeriesSuite) TestIsWindowsNano(c *gc.C) {
 	var isWindowsNanoTests = []struct {
 		series   string


### PR DESCRIPTION
When bootstrapping it's good to know what's an ubuntu
series, even if it's not supported.