### PR TITLE
Add support for Ubuntu focal

### DIFF
--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -76,6 +76,7 @@ var seriesVersions = map[string]string{
 	"cosmic":           "18.10",
 	"disco":            "19.04",
 	"eoan":             "19.10",
+	"focal":            "20.04",
 	"win2008r2":        "win2008r2",
 	"win2012hvr2":      "win2012hvr2",
 	"win2012hv":        "win2012hv",
@@ -131,7 +132,7 @@ type seriesVersion struct {
 	// WarningInfo shows any potential issues when parsing the series version
 	// information.
 	WarningInfo []string
-	// CreatedByLocalDistroInfo indecates that the series version was created
+	// CreatedByLocalDistroInfo indicates that the series version was created
 	// by the local distro-info information on the system.
 	// This is useful to understand why a version appears yet is not supported.
 	CreatedByLocalDistroInfo bool
@@ -189,12 +190,17 @@ var ubuntuSeries = map[string]seriesVersion{
 		Version: "18.10",
 	},
 	"disco": seriesVersion{
-		Version:   "19.04",
-		Supported: true,
+		Version: "19.04",
 	},
 	"eoan": seriesVersion{
 		Version:   "19.10",
 		Supported: true,
+	},
+	"focal": seriesVersion{
+		Version: "20.04",
+		LTS:     true,
+		// TODO - hard code to true when focal is released (fallback is to rely on distro-info.csv)
+		Supported: false,
 	},
 }
 
@@ -503,7 +509,7 @@ func SupportedLts() []string {
 
 	versions := []string{}
 	for _, version := range ubuntuSeries {
-		if !version.LTS {
+		if !version.LTS || !version.Supported {
 			continue
 		}
 		versions = append(versions, version.Version)
@@ -532,7 +538,7 @@ func LatestLts() string {
 
 	var latest string
 	for k, version := range ubuntuSeries {
-		if !version.LTS {
+		if !version.LTS || !version.Supported {
 			continue
 		}
 		if version.Version > ubuntuSeries[latest].Version {

--- a/series/supportedseries_linux_test.go
+++ b/series/supportedseries_linux_test.go
@@ -35,7 +35,7 @@ func (s *supportedSeriesSuite) TestSupportedSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(series.DistroInfo, filename)
 
-	expectedSeries := []string{"artful", "bionic", "cosmic", "disco", "eoan", "precise", "quantal", "raring", "saucy", "trusty", "utopic", "vivid", "wily", "xenial", "yakkety", "zesty"}
+	expectedSeries := []string{"artful", "bionic", "cosmic", "disco", "eoan", "focal", "precise", "quantal", "raring", "saucy", "trusty", "utopic", "vivid", "wily", "xenial", "yakkety", "zesty"}
 	series := series.SupportedSeries()
 	sort.Strings(series)
 	c.Assert(series, gc.DeepEquals, expectedSeries)
@@ -48,7 +48,7 @@ func (s *supportedSeriesSuite) TestUpdateSeriesVersions(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(series.DistroInfo, filename)
 
-	expectedSeries := []string{"artful", "bionic", "cosmic", "disco", "eoan", "precise", "quantal", "raring", "saucy", "trusty", "utopic", "vivid", "wily", "xenial", "yakkety", "zesty"}
+	expectedSeries := []string{"artful", "bionic", "cosmic", "disco", "eoan", "focal", "precise", "quantal", "raring", "saucy", "trusty", "utopic", "vivid", "wily", "xenial", "yakkety", "zesty"}
 	checkSeries := func() {
 		series := series.SupportedSeries()
 		sort.Strings(series)
@@ -64,7 +64,6 @@ func (s *supportedSeriesSuite) TestUpdateSeriesVersions(c *gc.C) {
 	checkSeries()
 
 	expectedSeries = append([]string{"ornery"}, expectedSeries...)
-	expectedSeries = append(expectedSeries, "firewolf")
 	sort.Strings(expectedSeries)
 	series.UpdateSeriesVersions()
 	checkSeries()
@@ -168,7 +167,7 @@ func (s *supportedSeriesSuite) TestSetLatestLtsForTesting(c *gc.C) {
 
 func (s *supportedSeriesSuite) TestSupportedLts(c *gc.C) {
 	got := series.SupportedLts()
-	want := []string{"trusty", "xenial", "bionic"}
+	want := []string{"xenial", "bionic"}
 	c.Assert(got, gc.DeepEquals, want)
 }
 
@@ -203,7 +202,8 @@ const distInfoData = `version,codename,series,created,release,eol,eol-server,eol
 18.04 LTS,Bionic Beaver,bionic,2017-10-19,2018-04-26,2023-04-26,2023-04-26,2028-04-26
 18.10,Cosmic Cuttlefish,cosmic,2018-04-26,2018-10-18,2019-07-18
 19.04,Disco Dingo,disco,2018-10-18,2019-04-18,2020-01-18
-19.10,Eoan EANIMAL,eoan,2019-04-18,2019-10-17,2020-07-17
+19.10,Eoan Ermine,eoan,2019-04-18,2019-10-17,2020-07-17
+20.04 LTS,Focal Fossa,focal,2019-10-17,2020-04-23,2025-04-23,2025-04-23,2030-04-23
 `
 
 const distInfoData2 = distInfoData + `

--- a/series/supportedseries_test.go
+++ b/series/supportedseries_test.go
@@ -147,6 +147,7 @@ func (s *supportedSeriesSuite) TestUbuntuSeriesVersion(c *gc.C) {
 		{"raring", "13.04"},
 		{"bionic", "18.04"},
 		{"eoan", "19.10"},
+		{"focal", "20.04"},
 	}
 	for _, v := range isUbuntuTests {
 		ver, err := series.UbuntuSeriesVersion(v.series)


### PR DESCRIPTION
Add "focal" to the list of known Ubuntu series.
Also, the distro-info.csv file contains the date range for which a series is supported. This was not being used. We now use that info to update the hard coded supported status for Ubuntu series. This allows the supported status for focal to be set to false and it will tick over to true when the release happens, without requiring a Juju update (so long as the user has an up-to-date distro-info.csv). "focal" needs to be set to false now as it is a LTS and we don't want to selected by default until it is ready.