### PR TITLE
add support for focal

### DIFF
--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -200,7 +200,7 @@ var ubuntuSeries = map[string]seriesVersion{
 		Version: "20.04",
 		LTS:     true,
 		// TODO - hard code to true when focal is released (fallback is to rely on distro-info.csv)
-		Supported: false,
+		Supported: true,
 	},
 }
 

--- a/series/supportedseries_linux_test.go
+++ b/series/supportedseries_linux_test.go
@@ -104,7 +104,7 @@ func (s *supportedSeriesSuite) TestSupportedJujuControllerSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(series.DistroInfo, filename)
 
-	expectedSeries := []string{"bionic", "disco", "eoan", "xenial"}
+	expectedSeries := []string{"bionic", "eoan", "xenial"}
 	series := series.SupportedJujuControllerSeries()
 	sort.Strings(series)
 	sort.Strings(expectedSeries)
@@ -118,7 +118,7 @@ func (s *supportedSeriesSuite) TestSupportedJujuWorkloadSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(series.DistroInfo, filename)
 
-	expectedSeries := []string{"bionic", "centos7", "disco", "eoan", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"}
+	expectedSeries := []string{"bionic", "centos7", "eoan", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"}
 	series := series.SupportedJujuWorkloadSeries()
 	sort.Strings(series)
 	sort.Strings(expectedSeries)
@@ -132,7 +132,7 @@ func (s *supportedSeriesSuite) TestSupportedJujuSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(series.DistroInfo, filename)
 
-	expectedSeries := []string{"bionic", "centos7", "disco", "eoan", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"}
+	expectedSeries := []string{"bionic", "centos7", "eoan", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"}
 	series := series.SupportedJujuSeries()
 	sort.Strings(series)
 	sort.Strings(expectedSeries)


### PR DESCRIPTION
adds support for focal.

With this, we can start the first deploy tests 
https://github.com/CanonicalLtd/juju-qa-jenkins/pull/378

First test run seems to be successful:
https://jenkins.juju.canonical.com/job/nw-deploy-focal-amd64-lxd/7/console