### PR TITLE
Ensure we handle no files

### DIFF
--- a/series/distroinfo.go
+++ b/series/distroinfo.go
@@ -71,10 +71,7 @@ func (d *DistroInfo) Refresh() error {
 	f, err := d.fileSystem.Open(d.path)
 	if err != nil {
 		// On non-Ubuntu systems this file won't exist but that's expected.
-		if errors.Cause(err) == os.ErrNotExist {
-			return nil
-		}
-		return errors.Trace(err)
+		return nil
 	}
 	defer func() {
 		_ = f.Close()

--- a/series/distroinfo.go
+++ b/series/distroinfo.go
@@ -23,6 +23,7 @@ const dateFormat = "2006-01-02"
 // FileSystem defines a interface for interacting with the host os.
 type FileSystem interface {
 	Open(string) (*os.File, error)
+	Exists(string) bool
 }
 
 // DistroInfoSerie holds the information about each distro.
@@ -68,10 +69,13 @@ func NewDistroInfo(path string) *DistroInfo {
 // Refresh will attempt to update the information it has about each distro and
 // if the distro is supported or not.
 func (d *DistroInfo) Refresh() error {
+	// On non-Ubuntu systems this file won't exist but that's expected.
+	if !d.fileSystem.Exists(d.path) {
+		return nil
+	}
 	f, err := d.fileSystem.Open(d.path)
 	if err != nil {
-		// On non-Ubuntu systems this file won't exist but that's expected.
-		return nil
+		return errors.Trace(err)
 	}
 	defer func() {
 		_ = f.Close()

--- a/series/distroinfo_test.go
+++ b/series/distroinfo_test.go
@@ -39,7 +39,7 @@ func (s *DistroInfoSuite) TestRefreshWithNoFile(c *gc.C) {
 	defer ctrl.Finish()
 
 	mockFileSystem := NewMockFileSystem(ctrl)
-	mockFileSystem.EXPECT().Open("bad file").Return(nil, os.ErrNotExist)
+	mockFileSystem.EXPECT().Exists("bad file").Return(false)
 
 	info := NewDistroInfo("bad file")
 	info.fileSystem = mockFileSystem
@@ -56,6 +56,7 @@ func (s *DistroInfoSuite) TestRefresh(c *gc.C) {
 	defer close()
 
 	mockFileSystem := NewMockFileSystem(ctrl)
+	mockFileSystem.EXPECT().Exists(UbuntuDistroInfo).Return(true)
 	mockFileSystem.EXPECT().Open(UbuntuDistroInfo).Return(tmpFile, nil)
 
 	info := NewDistroInfo(UbuntuDistroInfo)

--- a/series/distroinfo_test.go
+++ b/series/distroinfo_test.go
@@ -34,6 +34,20 @@ func (s *DistroInfoSuite) SetUpTest(c *gc.C) {
 	s.fixedTime = time.Date(2020, 03, 16, 0, 0, 0, 0, time.UTC).UTC()
 }
 
+func (s *DistroInfoSuite) TestRefreshWithNoFile(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockFileSystem := NewMockFileSystem(ctrl)
+	mockFileSystem.EXPECT().Open("bad file").Return(nil, os.ErrNotExist)
+
+	info := NewDistroInfo("bad file")
+	info.fileSystem = mockFileSystem
+
+	err := info.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *DistroInfoSuite) TestRefresh(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()

--- a/series/filesystem_mock_test.go
+++ b/series/filesystem_mock_test.go
@@ -33,6 +33,20 @@ func (m *MockFileSystem) EXPECT() *MockFileSystemMockRecorder {
 	return m.recorder
 }
 
+// Exists mocks base method
+func (m *MockFileSystem) Exists(arg0 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Exists", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Exists indicates an expected call of Exists
+func (mr *MockFileSystemMockRecorder) Exists(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockFileSystem)(nil).Exists), arg0)
+}
+
 // Open mocks base method
 func (m *MockFileSystem) Open(arg0 string) (*os.File, error) {
 	m.ctrl.T.Helper()

--- a/series/series_linux.go
+++ b/series/series_linux.go
@@ -129,3 +129,8 @@ type defaultFileSystem struct{}
 func (defaultFileSystem) Open(path string) (*os.File, error) {
 	return os.Open(path)
 }
+
+func (defaultFileSystem) Exists(path string) bool {
+	_, err := os.Stat(path)
+	return !os.IsNotExist(err)
+}

--- a/series/series_nonlinux.go
+++ b/series/series_nonlinux.go
@@ -24,3 +24,7 @@ type defaultFileSystem struct{}
 func (defaultFileSystem) Open(path string) (*os.File, error) {
 	return nil, os.ErrNotExist
 }
+
+func (defaultFileSystem) Exists(path string) bool {
+	return false
+}

--- a/series/supportedseries_linux_test.go
+++ b/series/supportedseries_linux_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -210,3 +211,20 @@ const distInfoData2 = distInfoData + `
 14.04 LTS,Firewolf,firewolf,2013-10-17,2014-04-17
 94.04 LTS,Ornery Omega,ornery,2094-10-17,2094-04-17,2099-04-17
 `
+
+type isolationSupportedSeriesSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&isolationSupportedSeriesSuite{})
+
+func (s *isolationSupportedSeriesSuite) TestBadFilePath(c *gc.C) {
+	d := c.MkDir()
+	filename := filepath.Join(d, "bad-file.csv")
+	s.PatchValue(series.UbuntuDistroInfoPath, filename)
+
+	expectedSeries := []string{"artful", "bionic", "centos7", "cosmic", "disco", "eoan", "focal", "genericlinux", "opensuseleap", "precise", "quantal", "raring", "saucy", "trusty", "utopic", "vivid", "wily", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial", "yakkety", "zesty"}
+	series := series.SupportedSeries()
+	sort.Strings(series)
+	c.Assert(series, gc.DeepEquals, expectedSeries)
+}


### PR DESCRIPTION
The following ensures that we handle situations where the file doesn't
exist on certain file systems OR if they've not run an apt update on the
distro info package.

The following just assumes that if no file exists we should always fall
back to the hardcoded defaults.

## Bug

https://bugs.launchpad.net/juju/+bug/1868322