### PR TITLE
Order supported series by version

### DIFF
--- a/series/supportedseries_linux_test.go
+++ b/series/supportedseries_linux_test.go
@@ -105,11 +105,9 @@ func (s *supportedSeriesSuite) TestSupportedJujuControllerSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(series.UbuntuDistroInfoPath, filename)
 
-	expectedSeries := []string{"bionic", "eoan", "focal", "xenial"}
+	expectedSeries := []string{"focal", "bionic", "xenial"}
 	series := series.SupportedJujuControllerSeries()
-	sort.Strings(series)
-	sort.Strings(expectedSeries)
-	c.Assert(series, jc.SameContents, expectedSeries)
+	c.Assert(series, jc.DeepEquals, expectedSeries)
 }
 
 func (s *supportedSeriesSuite) TestSupportedJujuWorkloadSeries(c *gc.C) {
@@ -119,11 +117,9 @@ func (s *supportedSeriesSuite) TestSupportedJujuWorkloadSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(series.UbuntuDistroInfoPath, filename)
 
-	expectedSeries := []string{"bionic", "centos7", "centos8", "eoan", "focal", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"}
+	expectedSeries := []string{"focal", "bionic", "xenial", "centos7", "centos8", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"}
 	series := series.SupportedJujuWorkloadSeries()
-	sort.Strings(series)
-	sort.Strings(expectedSeries)
-	c.Assert(series, jc.SameContents, expectedSeries)
+	c.Assert(series, jc.DeepEquals, expectedSeries)
 }
 
 func (s *supportedSeriesSuite) TestSupportedJujuSeries(c *gc.C) {
@@ -133,11 +129,9 @@ func (s *supportedSeriesSuite) TestSupportedJujuSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(series.UbuntuDistroInfoPath, filename)
 
-	expectedSeries := []string{"bionic", "centos7", "centos8", "eoan", "focal", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"}
+	expectedSeries := []string{"focal", "bionic", "xenial", "centos7", "centos8", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"}
 	series := series.SupportedJujuSeries()
-	sort.Strings(series)
-	sort.Strings(expectedSeries)
-	c.Assert(series, jc.SameContents, expectedSeries)
+	c.Assert(series, jc.DeepEquals, expectedSeries)
 }
 
 func (s *supportedSeriesSuite) TestLatestLts(c *gc.C) {


### PR DESCRIPTION
The fact that we lose so much information when trying to gain
knowledge of a series makes it hard to make rational decisions about
which series to pick.

Rather than re-write this god-awful package, we can order the series and
then use that to at least make the results predictable.