### PR TITLE
Remove the default supported lts function

### DIFF
--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -115,12 +115,6 @@ var kubernetesSeries = map[string]string{
 	"kubernetes": "kubernetes",
 }
 
-// DefaultSupportedLTS returns the latest LTS that Juju supports and is
-// compatible with.
-func DefaultSupportedLTS() string {
-	return "bionic"
-}
-
 // seriesVersion represents a ubuntu series that includes the version, if the
 // series is an LTS and the supported defines if Juju supports the series
 // version.

--- a/series/supportedseries_test.go
+++ b/series/supportedseries_test.go
@@ -58,11 +58,6 @@ var getOSFromSeriesTests = []struct {
 },
 }
 
-func (s *supportedSeriesSuite) TestDefaultSupportedLTS(c *gc.C) {
-	name := series.DefaultSupportedLTS()
-	c.Assert(name, gc.Equals, "bionic")
-}
-
 func (s *supportedSeriesSuite) TestGetOSFromSeries(c *gc.C) {
 	for _, t := range getOSFromSeriesTests {
 		got, err := series.GetOSFromSeries(t.series)


### PR DESCRIPTION
The function has been moved to `juju/juju` directly as this should be
locked stepped with juju, this isn't just a default supported LTS, but
what juju uses as the default supported series.
