### PR TITLE
Support the focal series

### DIFF
--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -202,10 +202,9 @@ var ubuntuSeries = map[string]seriesVersion{
 		Supported: true,
 	},
 	"focal": {
-		Version: "20.04",
-		LTS:     true,
-		// TODO - hard code to true when focal is released (fallback is to rely on distro-info.csv)
-		Supported: false,
+		Version:   "20.04",
+		LTS:       true,
+		Supported: true,
 	},
 	"groovy": {
 		Version:   "20.10",


### PR DESCRIPTION
This switches the focal series from not supported to supported. If
you're already running on ubuntu os, this will be switched to supported
at runtime.