### PR TITLE
Focal is also ESM supported

### DIFF
--- a/series/supportedseries_linux_test.go
+++ b/series/supportedseries_linux_test.go
@@ -77,10 +77,9 @@ func (s *supportedSeriesSuite) TestESMSupportedJujuSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(series.UbuntuDistroInfoPath, filename)
 
-	expectedSeries := []string{"bionic", "trusty", "xenial"}
+	expectedSeries := []string{"focal", "bionic", "xenial", "trusty"}
 	series := series.ESMSupportedJujuSeries()
-	sort.Strings(series)
-	c.Assert(series, jc.SameContents, expectedSeries)
+	c.Assert(series, jc.DeepEquals, expectedSeries)
 }
 
 func (s *supportedSeriesSuite) TestOSSeries(c *gc.C) {


### PR DESCRIPTION
I've re-worked the supported series so that it correctly sorts for esm
releases as well. This should make this package easier to manage with I
the series is correctly sorted when using it.