### PR TITLE
Add new LocalSeriesVersionInfo() method

### DIFF
--- a/series/export_linux_test.go
+++ b/series/export_linux_test.go
@@ -14,7 +14,7 @@ var (
 // This is not concurrent safe.
 func HideUbuntuSeries() func() {
 	origSeries := ubuntuSeries
-	ubuntuSeries = make(map[string]seriesVersion)
+	ubuntuSeries = make(map[string]SeriesVersionInfo)
 	return func() {
 		ubuntuSeries = origSeries
 	}

--- a/series/export_test.go
+++ b/series/export_test.go
@@ -24,6 +24,6 @@ func SetSeriesVersions(value map[string]string) func() {
 }
 
 // UbuntuSupportedSeries exports the ubuntuSeries for testing.
-func UbuntuSupportedSeries() map[string]seriesVersion {
+func UbuntuSupportedSeries() map[string]SeriesVersionInfo {
 	return ubuntuSeries
 }

--- a/series/series_nonlinux.go
+++ b/series/series_nonlinux.go
@@ -5,13 +5,22 @@
 
 package series
 
-import "os"
+import (
+	"os"
+
+	jujuos "github.com/juju/os"
+)
 
 // TODO(ericsnow) Refactor dependents so we can remove this for non-linux.
 
 // ReleaseVersion is a function that has no meaning except on linux.
 func ReleaseVersion() string {
 	return ""
+}
+
+// // LocalSeriesVersionInfo is a function that has no meaning except on Linux.
+func LocalSeriesVersionInfo() (jujuos.OSType, map[string]SeriesVersionInfo, error) {
+	return jujuos.Unknown, nil, nil
 }
 
 func updateLocalSeriesVersions() error {

--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -119,10 +119,10 @@ func DefaultSupportedLTS() string {
 	return "bionic"
 }
 
-// seriesVersion represents a ubuntu series that includes the version, if the
+// SeriesVersionInfo represents a ubuntu series that includes the version, if the
 // series is an LTS and the supported defines if Juju supports the series
 // version.
-type seriesVersion struct {
+type SeriesVersionInfo struct {
 	Version string
 	// LTS provides a lookup for a LTS series.  Like seriesVersions,
 	// the values here are current at the time of writing.
@@ -141,7 +141,7 @@ type seriesVersion struct {
 	CreatedByLocalDistroInfo bool
 }
 
-var ubuntuSeries = map[string]seriesVersion{
+var ubuntuSeries = map[string]SeriesVersionInfo{
 	"precise": {
 		Version: "12.04",
 	},
@@ -211,7 +211,7 @@ var ubuntuSeries = map[string]seriesVersion{
 	},
 }
 
-var nonUbuntuSeries = map[string]seriesVersion{
+var nonUbuntuSeries = map[string]SeriesVersionInfo{
 	"win2008r2": {
 		Version:   "win2008r2",
 		Supported: true,
@@ -579,7 +579,7 @@ func updateVersionSeries() {
 	versionSeries = reverseSeriesVersion()
 }
 
-// reverseSeriesVersion returns reverse of seriesVersion map,
+// reverseSeriesVersion returns reverse of SeriesVersionInfo map,
 // keyed on versions with series as values.
 func reverseSeriesVersion() map[string]string {
 	reverse := make(map[string]string, len(seriesVersions))
@@ -601,8 +601,8 @@ func SupportedSeries() []string {
 	return series
 }
 
-func allSeriesVersions() map[string]seriesVersion {
-	all := map[string]seriesVersion{}
+func allSeriesVersions() map[string]SeriesVersionInfo {
+	all := map[string]SeriesVersionInfo{}
 	for k, v := range ubuntuSeries {
 		all[k] = v
 	}

--- a/series/supportedseries_linux_test.go
+++ b/series/supportedseries_linux_test.go
@@ -70,6 +70,29 @@ func (s *supportedSeriesSuite) TestUpdateSeriesVersions(c *gc.C) {
 	checkSeries()
 }
 
+func (s *supportedSeriesSuite) TestLocalSeriesVersionInfo(c *gc.C) {
+	d := c.MkDir()
+	filename := filepath.Join(d, "ubuntu.csv")
+	err := ioutil.WriteFile(filename, []byte(distInfoData), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	s.PatchValue(series.UbuntuDistroInfoPath, filename)
+
+	err = ioutil.WriteFile(filename, []byte(distInfoData2), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	gotOs, updated, err := series.LocalSeriesVersionInfo()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(gotOs, gc.Equals, os.Ubuntu)
+	c.Assert(updated, jc.DeepEquals, series.UbuntuSupportedSeries())
+	ornery, ok := updated["ornery"]
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(ornery, jc.DeepEquals, series.SeriesVersionInfo{
+		Version:                  "94.04 LTS",
+		LTS:                      true,
+		CreatedByLocalDistroInfo: true,
+	})
+}
+
 func (s *supportedSeriesSuite) TestESMSupportedJujuSeries(c *gc.C) {
 	d := c.MkDir()
 	filename := filepath.Join(d, "ubuntu.csv")


### PR DESCRIPTION
A new LocalSeriesVersionInfo() is added to return the latest local series info.
This uses an existing internal method and allows callers to ask for the latest info and use it.
The new method also returns the OS which the updated info belongs to.