### PR TITLE
Add new LocalSeriesVersionInfo() method

### DIFF
--- a/series/export_linux_test.go
+++ b/series/export_linux_test.go
@@ -14,7 +14,7 @@ var (
 // This is not concurrent safe.
 func HideUbuntuSeries() func() {
 	origSeries := ubuntuSeries
-	ubuntuSeries = make(map[string]seriesVersion)
+	ubuntuSeries = make(map[string]SeriesVersionInfo)
 	return func() {
 		ubuntuSeries = origSeries
 	}

--- a/series/export_test.go
+++ b/series/export_test.go
@@ -24,6 +24,6 @@ func SetSeriesVersions(value map[string]string) func() {
 }
 
 // UbuntuSupportedSeries exports the ubuntuSeries for testing.
-func UbuntuSupportedSeries() map[string]seriesVersion {
+func UbuntuSupportedSeries() map[string]SeriesVersionInfo {
 	return ubuntuSeries
 }

--- a/series/series_linux.go
+++ b/series/series_linux.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/juju/errors"
 	jujuos "github.com/juju/os/v2"
@@ -17,13 +16,6 @@ var (
 	// osReleaseFile is the name of the file that is read in order to determine
 	// the linux type release version.
 	osReleaseFile = "/etc/os-release"
-)
-
-const (
-	// this is just for an approximation in an error case, when the eol
-	// date has a parse error.
-	day  = 24 * time.Hour
-	year = 365 * day
 )
 
 func readSeries() (string, error) {
@@ -61,7 +53,7 @@ func getValue(from map[string]string, val string) (string, error) {
 	return "unknown", errors.New("could not determine series")
 }
 
-func getValueFromSeriesVersion(from map[string]seriesVersion, val string) (string, error) {
+func getValueFromSeriesVersion(from map[string]SeriesVersionInfo, val string) (string, error) {
 	for s, version := range from {
 		if version.Version == val {
 			return s, nil
@@ -79,6 +71,14 @@ func ReleaseVersion() string {
 		return ""
 	}
 	return release["VERSION_ID"]
+}
+
+// LocalSeriesVersionInfo returns the local series versions and OS type.
+func LocalSeriesVersionInfo() (jujuos.OSType, map[string]SeriesVersionInfo, error) {
+	if err := updateLocalSeriesVersions(); err != nil {
+		return jujuos.Unknown, nil, errors.Trace(err)
+	}
+	return jujuos.Ubuntu, ubuntuSeries, nil
 }
 
 // updateLocalSeriesVersions updates seriesVersions from
@@ -111,7 +111,7 @@ func updateLocalSeriesVersions() error {
 			continue
 		}
 
-		ubuntuSeries[seriesName] = seriesVersion{
+		ubuntuSeries[seriesName] = SeriesVersionInfo{
 			Version:                  version.Version,
 			Supported:                supported,
 			ESMSupported:             esm,

--- a/series/series_nonlinux.go
+++ b/series/series_nonlinux.go
@@ -5,13 +5,22 @@
 
 package series
 
-import "os"
+import (
+	"os"
+
+	jujuos "github.com/juju/os"
+)
 
 // TODO(ericsnow) Refactor dependents so we can remove this for non-linux.
 
 // ReleaseVersion is a function that has no meaning except on linux.
 func ReleaseVersion() string {
 	return ""
+}
+
+// LocalSeriesVersionInfo is a function that has no meaning except on Linux.
+func LocalSeriesVersionInfo() (jujuos.OSType, map[string]SeriesVersionInfo, error) {
+	return jujuos.Unknown, nil, nil
 }
 
 func updateLocalSeriesVersions() error {

--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -116,10 +116,10 @@ var kubernetesSeries = map[string]string{
 	"kubernetes": "kubernetes",
 }
 
-// seriesVersion represents a ubuntu series that includes the version, if the
+// SeriesVersionInfo represents a ubuntu series that includes the version, if the
 // series is an LTS and the supported defines if Juju supports the series
 // version.
-type seriesVersion struct {
+type SeriesVersionInfo struct {
 	Version string
 	// LTS provides a lookup for a LTS series.  Like seriesVersions,
 	// the values here are current at the time of writing.
@@ -138,7 +138,7 @@ type seriesVersion struct {
 	CreatedByLocalDistroInfo bool
 }
 
-var ubuntuSeries = map[string]seriesVersion{
+var ubuntuSeries = map[string]SeriesVersionInfo{
 	"precise": {
 		Version: "12.04",
 	},
@@ -211,7 +211,7 @@ var ubuntuSeries = map[string]seriesVersion{
 	},
 }
 
-var nonUbuntuSeries = map[string]seriesVersion{
+var nonUbuntuSeries = map[string]SeriesVersionInfo{
 	"win2008r2": {
 		Version:   "win2008r2",
 		Supported: true,
@@ -603,7 +603,7 @@ func SupportedSeries() []string {
 
 type namedSeriesVersion struct {
 	Name          string
-	SeriesVersion seriesVersion
+	SeriesVersion SeriesVersionInfo
 	Version       float64
 }
 

--- a/series/supportedseries_linux_test.go
+++ b/series/supportedseries_linux_test.go
@@ -70,6 +70,29 @@ func (s *supportedSeriesSuite) TestUpdateSeriesVersions(c *gc.C) {
 	checkSeries()
 }
 
+func (s *supportedSeriesSuite) TestLocalSeriesVersionInfo(c *gc.C) {
+	d := c.MkDir()
+	filename := filepath.Join(d, "ubuntu.csv")
+	err := ioutil.WriteFile(filename, []byte(distInfoData), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	s.PatchValue(series.UbuntuDistroInfoPath, filename)
+
+	err = ioutil.WriteFile(filename, []byte(distInfoData2), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	gotOs, updated, err := series.LocalSeriesVersionInfo()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(gotOs, gc.Equals, os.Ubuntu)
+	c.Assert(updated, jc.DeepEquals, series.UbuntuSupportedSeries())
+	ornery, ok := updated["ornery"]
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(ornery, jc.DeepEquals, series.SeriesVersionInfo{
+		Version:                  "94.04 LTS",
+		LTS:                      true,
+		CreatedByLocalDistroInfo: true,
+	})
+}
+
 func (s *supportedSeriesSuite) TestESMSupportedJujuSeries(c *gc.C) {
 	d := c.MkDir()
 	filename := filepath.Join(d, "ubuntu.csv")


### PR DESCRIPTION
A new LocalSeriesVersionInfo() is added to return the latest local series info.
This uses an existing internal method and allows callers to ask for the latest info and use it.
The new method also returns the OS which the updated info belongs to.