### PR TITLE
Get OS from series using a hint

### DIFF
--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -450,6 +450,34 @@ func getOSFromSeries(series string) (os.OSType, error) {
 	return os.Unknown, errors.Trace(unknownOSForSeriesError(series))
 }
 
+// GetOSFromSeriesWithBaseOS will return the operating system based
+// on the series and optional os base that is passed to it
+func GetOSFromSeriesWithBaseOS(series, baseOS string) (os.OSType, error) {
+	if series == "" {
+		return os.Unknown, errors.NotValidf("series %q", series)
+	}
+	osType, err := getOSFromSeriesWithBaseOS(series, baseOS)
+	if err == nil {
+		return osType, nil
+	}
+
+	seriesVersionsMutex.Lock()
+	defer seriesVersionsMutex.Unlock()
+
+	updateSeriesVersionsOnce()
+	return getOSFromSeriesWithBaseOS(series, baseOS)
+}
+
+func getOSFromSeriesWithBaseOS(series, baseOS string) (os.OSType, error) {
+	switch strings.ToLower(baseOS) {
+	case "centos":
+		if _, ok := centosSeries["centos"+series]; ok {
+			return os.CentOS, nil
+		}
+	}
+	return getOSFromSeries(series)
+}
+
 var (
 	seriesVersionsMutex sync.Mutex
 )

--- a/series/supportedseries_test.go
+++ b/series/supportedseries_test.go
@@ -83,6 +83,61 @@ func (s *supportedSeriesSuite) TestUnknownOSFromSeries(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `unknown OS for series: "Xuanhuaceratops"`)
 }
 
+var getOSFromSeriesBaseOSTests = []struct {
+	series, baseOS string
+	want           os.OSType
+	err            string
+}{{
+	series: "precise",
+	baseOS: "ubuntu",
+	want:   os.Ubuntu,
+}, {
+	series: "win2012r2",
+	baseOS: "windows",
+	want:   os.Windows,
+}, {
+	series: "win2016nano",
+	baseOS: "windows",
+	want:   os.Windows,
+}, {
+	series: "mountainlion",
+	baseOS: "osx",
+	want:   os.OSX,
+}, {
+	series: "7",
+	baseOS: "centos",
+	want:   os.CentOS,
+}, {
+	series: "opensuseleap",
+	baseOS: "opensuse",
+	want:   os.OpenSUSE,
+}, {
+	series: "kubernetes",
+	baseOS: "kubernetes",
+	want:   os.Kubernetes,
+}, {
+	series: "genericlinux",
+	baseOS: "genericlinux",
+	want:   os.GenericLinux,
+}, {
+	series: "",
+	err:    "series \"\" not valid",
+},
+}
+
+func (s *supportedSeriesSuite) TestGetOSFromSeriesWithBaseOS(c *gc.C) {
+	for _, t := range getOSFromSeriesBaseOSTests {
+		c.Logf("series %q os %q", t.series, t.baseOS)
+		got, err := series.GetOSFromSeriesWithBaseOS(t.series, t.baseOS)
+		if t.err != "" {
+			c.Assert(err, gc.ErrorMatches, t.err)
+		} else {
+			c.Check(err, jc.ErrorIsNil)
+			c.Assert(got, gc.Equals, t.want)
+		}
+	}
+}
+
 func setSeriesTestData() {
 	series.SetSeriesVersions(map[string]string{
 		"trusty":       "14.04",


### PR DESCRIPTION
The following function helps provide a hint to help when normalising the
OS from a series. For OSes like centos that just have a number after it,
then the series of centos7 is fine, but fails when someone wants to just
pass 7. Unless we know the potential os as a hint (centos) then we can
then correctly normalise the value.