### PR TITLE
Correctly report valid series for juju 2.9

### DIFF
--- a/series/series_linux.go
+++ b/series/series_linux.go
@@ -106,14 +106,14 @@ func updateLocalSeriesVersions() error {
 		supported := version.Supported(now)
 
 		if us, ok := ubuntuSeries[seriesName]; ok {
-			us.Supported = supported
+			us.Supported = us.Supported && supported
 			ubuntuSeries[seriesName] = us
 			continue
 		}
 
 		ubuntuSeries[seriesName] = SeriesVersionInfo{
 			Version:                  version.Version,
-			Supported:                supported,
+			Supported:                false,
 			ESMSupported:             esm,
 			LTS:                      version.LTS(),
 			CreatedByLocalDistroInfo: true,

--- a/series/series_linux_test.go
+++ b/series/series_linux_test.go
@@ -70,11 +70,11 @@ func (s *linuxVersionSuite) TestOSVersion(c *gc.C) {
 	c.Assert(precise.CreatedByLocalDistroInfo, jc.IsFalse)
 	c.Assert(precise.Supported, jc.IsFalse)
 
-	// Bionic isn't poly-filled and is supported.
+	// Bionic isn't poly-filled and isn't supported.
 	bionic, ok := series["bionic"]
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(bionic.CreatedByLocalDistroInfo, jc.IsFalse)
-	c.Assert(bionic.Supported, jc.IsTrue)
+	c.Assert(bionic.Supported, jc.IsFalse)
 
 	// Spock is poly-filled and isn't supported.
 	spock, ok := series["spock"]

--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -83,6 +83,10 @@ var seriesVersions = map[string]string{
 	"hirsute":          "21.04",
 	"impish":           "21.10",
 	"jammy":            "22.04",
+	"kinetic":          "22.10",
+	"lunar":            "23.04",
+	"mantic":           "23.10",
+	"noble":            "24.04",
 	"win2008r2":        "win2008r2",
 	"win2012hvr2":      "win2012hvr2",
 	"win2012hv":        "win2012hv",
@@ -218,8 +222,8 @@ var ubuntuSeries = map[string]SeriesVersionInfo{
 	"jammy": {
 		Version:      "22.04",
 		LTS:          true,
-		Supported:    false,
-		ESMSupported: false,
+		Supported:    true,
+		ESMSupported: true,
 	},
 	"kinetic": {
 		Version:   "22.10",

--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -172,7 +172,6 @@ var ubuntuSeries = map[string]SeriesVersionInfo{
 	"xenial": {
 		Version:      "16.04",
 		LTS:          true,
-		Supported:    true,
 		ESMSupported: true,
 	},
 	"yakkety": {
@@ -187,7 +186,6 @@ var ubuntuSeries = map[string]SeriesVersionInfo{
 	"bionic": {
 		Version:      "18.04",
 		LTS:          true,
-		Supported:    true,
 		ESMSupported: true,
 	},
 	"cosmic": {
@@ -222,6 +220,24 @@ var ubuntuSeries = map[string]SeriesVersionInfo{
 		LTS:          true,
 		Supported:    false,
 		ESMSupported: false,
+	},
+	"kinetic": {
+		Version:   "22.10",
+		Supported: false,
+	},
+	"lunar": {
+		Version:   "23.04",
+		Supported: false,
+	},
+	"mantic": {
+		Version:   "23.10",
+		Supported: false,
+	},
+	"noble": {
+		Version:      "24.40",
+		LTS:          true,
+		ESMSupported: false,
+		Supported:    false,
 	},
 }
 

--- a/series/supportedseries_linux_test.go
+++ b/series/supportedseries_linux_test.go
@@ -100,7 +100,7 @@ func (s *supportedSeriesSuite) TestESMSupportedJujuSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(series.UbuntuDistroInfoPath, filename)
 
-	expectedSeries := []string{"focal", "bionic", "xenial", "trusty"}
+	expectedSeries := []string{"jammy", "focal", "bionic", "xenial", "trusty"}
 	series := series.ESMSupportedJujuSeries()
 	c.Assert(series, jc.DeepEquals, expectedSeries)
 }
@@ -243,7 +243,7 @@ func (s *isolationSupportedSeriesSuite) TestBadFilePath(c *gc.C) {
 	filename := filepath.Join(d, "bad-file.csv")
 	s.PatchValue(series.UbuntuDistroInfoPath, filename)
 
-	expectedSeries := []string{"artful", "bionic", "centos7", "centos8", "centos9", "cosmic", "disco", "eoan", "focal", "genericlinux", "groovy", "hirsute", "impish", "jammy", "opensuseleap", "precise", "quantal", "raring", "saucy", "trusty", "utopic", "vivid", "wily", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial", "yakkety", "zesty"}
+	expectedSeries := []string{"artful", "bionic", "centos7", "centos8", "centos9", "cosmic", "disco", "eoan", "focal", "genericlinux", "groovy", "hirsute", "impish", "jammy", "kinetic", "lunar", "mantic", "noble", "opensuseleap", "precise", "quantal", "raring", "saucy", "trusty", "utopic", "vivid", "wily", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial", "yakkety", "zesty"}
 	series := series.SupportedSeries()
 	sort.Strings(series)
 	c.Assert(series, gc.DeepEquals, expectedSeries)

--- a/series/supportedseries_linux_test.go
+++ b/series/supportedseries_linux_test.go
@@ -127,7 +127,7 @@ func (s *supportedSeriesSuite) TestSupportedJujuControllerSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(series.UbuntuDistroInfoPath, filename)
 
-	expectedSeries := []string{"groovy", "focal", "bionic", "xenial"}
+	expectedSeries := []string{"focal"}
 	series := series.SupportedJujuControllerSeries()
 	c.Assert(series, jc.DeepEquals, expectedSeries)
 }
@@ -139,7 +139,7 @@ func (s *supportedSeriesSuite) TestSupportedJujuWorkloadSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(series.UbuntuDistroInfoPath, filename)
 
-	expectedSeries := []string{"groovy", "focal", "bionic", "xenial", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"}
+	expectedSeries := []string{"focal", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"}
 	series := series.SupportedJujuWorkloadSeries()
 	c.Assert(series, jc.DeepEquals, expectedSeries)
 }
@@ -151,7 +151,7 @@ func (s *supportedSeriesSuite) TestSupportedJujuSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(series.UbuntuDistroInfoPath, filename)
 
-	expectedSeries := []string{"groovy", "focal", "bionic", "xenial", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"}
+	expectedSeries := []string{"focal", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"}
 	series := series.SupportedJujuSeries()
 	c.Assert(series, jc.DeepEquals, expectedSeries)
 }
@@ -184,7 +184,7 @@ func (s *supportedSeriesSuite) TestSetLatestLtsForTesting(c *gc.C) {
 
 func (s *supportedSeriesSuite) TestSupportedLts(c *gc.C) {
 	got := series.SupportedLts()
-	want := []string{"xenial", "bionic", "focal"}
+	want := []string{"focal"}
 	c.Assert(got, gc.DeepEquals, want)
 }
 


### PR DESCRIPTION
In version 2.9 new ubuntu series that appear in the distro info are automatically marked as supported. This is because in this package, when they are read out, the default is `Supported:true`. This PR changes that to false. This method of determinng series is not used by any of the supported 3.x versions of Juju, only by Juju 2.9. 

This PR updates the supported os series supported by juju. It keeps a list of known supported versions and if a version is not in the list it is not marked as supported when it is found in the os distro-info. 