### PR TITLE
Update hard-coded supported series

### DIFF
--- a/series/series_linux_test.go
+++ b/series/series_linux_test.go
@@ -70,11 +70,11 @@ func (s *linuxVersionSuite) TestOSVersion(c *gc.C) {
 	c.Assert(precise.CreatedByLocalDistroInfo, jc.IsFalse)
 	c.Assert(precise.Supported, jc.IsFalse)
 
-	// Bionic isn't poly-filled and is supported.
-	bionic, ok := series["bionic"]
+	// Focal isn't poly-filled and is supported.
+	focal, ok := series["focal"]
 	c.Assert(ok, jc.IsTrue)
-	c.Assert(bionic.CreatedByLocalDistroInfo, jc.IsFalse)
-	c.Assert(bionic.Supported, jc.IsTrue)
+	c.Assert(focal.CreatedByLocalDistroInfo, jc.IsFalse)
+	c.Assert(focal.Supported, jc.IsTrue)
 
 	// Spock is poly-filled and isn't supported.
 	spock, ok := series["spock"]

--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -156,9 +156,8 @@ var ubuntuSeries = map[string]SeriesVersionInfo{
 		Version: "13.10",
 	},
 	"trusty": {
-		Version:      "14.04",
-		LTS:          true,
-		ESMSupported: true,
+		Version: "14.04",
+		LTS:     true,
 	},
 	"utopic": {
 		Version: "14.10",
@@ -170,10 +169,8 @@ var ubuntuSeries = map[string]SeriesVersionInfo{
 		Version: "15.10",
 	},
 	"xenial": {
-		Version:      "16.04",
-		LTS:          true,
-		Supported:    true,
-		ESMSupported: true,
+		Version: "16.04",
+		LTS:     true,
 	},
 	"yakkety": {
 		Version: "16.10",
@@ -185,10 +182,8 @@ var ubuntuSeries = map[string]SeriesVersionInfo{
 		Version: "17.10",
 	},
 	"bionic": {
-		Version:      "18.04",
-		LTS:          true,
-		Supported:    true,
-		ESMSupported: true,
+		Version: "18.04",
+		LTS:     true,
 	},
 	"cosmic": {
 		Version: "18.10",
@@ -206,22 +201,34 @@ var ubuntuSeries = map[string]SeriesVersionInfo{
 		ESMSupported: true,
 	},
 	"groovy": {
-		Version:   "20.10",
-		Supported: true,
+		Version: "20.10",
 	},
 	"hirsute": {
-		Version:   "21.04",
-		Supported: false,
+		Version: "21.04",
 	},
 	"impish": {
-		Version:   "21.10",
-		Supported: false,
+		Version: "21.10",
 	},
 	"jammy": {
 		Version:      "22.04",
 		LTS:          true,
-		Supported:    false,
-		ESMSupported: false,
+		Supported:    true,
+		ESMSupported: true,
+	},
+	"kinetic": {
+		Version: "22.10",
+	},
+	"lunar": {
+		Version: "23.04",
+	},
+	"mantic": {
+		Version: "23.10",
+	},
+	"noble": {
+		Version:      "24.04",
+		LTS:          true,
+		Supported:    true,
+		ESMSupported: true,
 	},
 }
 

--- a/series/supportedseries_linux_test.go
+++ b/series/supportedseries_linux_test.go
@@ -100,7 +100,7 @@ func (s *supportedSeriesSuite) TestESMSupportedJujuSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(series.UbuntuDistroInfoPath, filename)
 
-	expectedSeries := []string{"focal", "bionic", "xenial", "trusty"}
+	expectedSeries := []string{"noble", "jammy", "focal"}
 	series := series.ESMSupportedJujuSeries()
 	c.Assert(series, jc.DeepEquals, expectedSeries)
 }


### PR DESCRIPTION
All of this supported series/bases sniffing is going away very soon. Hopefully this should be the final update

We no longer support any OSes before focal. So ensure focal, jammy, noble are supported here. At the moment, no interim releases are supported

## QA Steps

Create a noble multipass vm
```
$ multipass launch noble -n noble
(enable ssh access to juju client)
$ multipass transfer ~/.local/share/juju/ssh/juju_id_rsa.pub noble:~/.ssh/authorised_keys
```

Add a manual cloud
```
$ multipass ls
Name                    State             IPv4             Image
noble                   Running           10.90.50.234     Ubuntu 24.04 LTS

$ cat ~/.local/share/juju/clouds.yaml
...
  multipass-noble:
    type: manual
    endpoint: ubuntu@10.90.50.234
    regions:
      default: {}
...
```

compile juju using this library
```
$ cd juju/juju
$ git diff
$ git diff
diff --git a/go.mod b/go.mod
index 43eb5f5a29..62ecd73a25 100644
--- a/go.mod
+++ b/go.mod
@@ -309,3 +309,5 @@ require (
 )

 replace gopkg.in/yaml.v2 => github.com/juju/yaml/v2 v2.0.0
+
+replace github.com/juju/os/v2 => /path/to/juju/os

$ make install
```

Bootstrap (note: this will fail, but that will be because the charm is not released to noble yet)
```
$ juju bootstrap multipass-noble
Creating Juju controller "multipass-noble-default" on multipass-noble/default
Looking for packaged Juju agent version 3.5.1 for amd64
No packaged binary found, preparing local Juju agent binary
Installing Juju agent on bootstrap instance
Running machine configuration script...
Warning: Permanently added '10.90.50.234' (ED25519) to the list of known hosts.
...
ERROR cannot deploy controller application: deploying charmhub controller charm: resolving "ch:juju-controller": selecting releases: charm or bundle not found for channel "3.5/stable", base "amd64/ubuntu/24.04"
available releases are:
  channel "3.1/beta": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.0/stable": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.0/candidate": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "latest/stable": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "4.0/edge": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.5/edge": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.4/beta": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.3/stable": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "4.0/stable": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "4.0/beta": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.3/candidate": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "latest/candidate": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.3/edge": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "latest/beta": available bases are: ubuntu@22.04, ubuntu@20.04, ubuntu@18.04, ubuntu@16.04
  channel "3.5/stable": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.1/edge": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.0/edge": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.4/candidate": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.2/beta": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.2/edge": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.6/stable": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.6/candidate": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.6/beta": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.6/edge": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.5/candidate": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.1/candidate": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "latest/edge": available bases are: ubuntu@22.04, ubuntu@20.04, ubuntu@18.04, ubuntu@16.04
  channel "3.4/stable": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.4/edge": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.3/beta": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.0/beta": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "4.0/candidate": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.5/beta": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.2/stable": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.2/candidate": available bases are: ubuntu@22.04, ubuntu@20.04
  channel "3.1/stable": available bases are: ubuntu@22.04, ubuntu@20.04
ERROR failed to bootstrap model: subprocess encountered error code 1
ERROR cannot reset current controller to "multipass-jammy-default": controller multipass-jammy-default not found
```