### PR TITLE
Fix noble version

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
 
-      - name: Set up Go 1.14
+      - name: Set up Go 1.17
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.14
+          go-version: 1.17
         id: go
 
       - name: Checkout

--- a/series/series.go
+++ b/series/series.go
@@ -100,6 +100,8 @@ func macOSXSeriesFromKernelVersion(getKernelVersion func() (string, error)) (str
 // macOSXSeries maps from the Darwin Kernel Major Version to the Mac OSX
 // series.
 var macOSXSeries = map[int]string{
+	23: "sonoma",
+	22: "ventura",
 	21: "monterey",
 	20: "bigsur",
 	19: "catalina",

--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -238,7 +238,7 @@ var ubuntuSeries = map[string]SeriesVersionInfo{
 		Supported: false,
 	},
 	"noble": {
-		Version:      "24.40",
+		Version:      "24.04",
 		LTS:          true,
 		ESMSupported: false,
 		Supported:    false,


### PR DESCRIPTION
Fix noble version

noble series was accidentally hardcoded to be ubuntu 24.40

Fix this to be 24.04